### PR TITLE
feat(prune): add webfetch, glob, and grep output pruning

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,14 +4,8 @@
   "workspaces": {
     "": {
       "name": "magic-compact",
-      "dependencies": {
-        "@opencode-ai/sdk": "^1.17.9",
-        "gpt-tokenizer": "^3.4.0",
-        "zod": "^4.4.3",
-      },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@opencode-ai/plugin": "^1.17.9",
         "@types/bun": "latest",
         "eslint": "^10.5.0",
         "eslint-config-prettier": "^10.1.8",
@@ -19,6 +13,23 @@
         "prettier": "^3.8.4",
         "typescript": "^5",
         "typescript-eslint": "^8.61.1",
+      },
+    },
+    "packages/claude-code-plugin": {
+      "name": "@magic-compact/claude-code-plugin",
+      "version": "1.0.0",
+    },
+    "packages/common": {
+      "name": "@magic-compact/common",
+      "version": "1.0.0",
+    },
+    "packages/opencode-plugin": {
+      "name": "magic-compact",
+      "version": "1.0.0",
+      "dependencies": {
+        "@opencode-ai/sdk": "^1.17.9",
+        "gpt-tokenizer": "^3.4.0",
+        "zod": "^4.4.3",
       },
       "peerDependencies": {
         "@opencode-ai/plugin": ">=1.17.9",
@@ -51,6 +62,10 @@
     "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
 
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
+
+    "@magic-compact/claude-code-plugin": ["@magic-compact/claude-code-plugin@workspace:packages/claude-code-plugin"],
+
+    "@magic-compact/common": ["@magic-compact/common@workspace:packages/common"],
 
     "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ=="],
 
@@ -193,6 +208,8 @@
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
 
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
+    "magic-compact": ["magic-compact@workspace:packages/opencode-plugin"],
 
     "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 

--- a/packages/opencode-plugin/src/compact/prune.ts
+++ b/packages/opencode-plugin/src/compact/prune.ts
@@ -1,9 +1,6 @@
 import type { Part, ToolPart } from "@opencode-ai/sdk/v2";
 import { unwrap, type V2Client } from "../api";
-import {
-  inputOmissionNotice,
-  outputOmissionNotice,
-} from "./constants";
+import { inputOmissionNotice, outputOmissionNotice } from "./constants";
 import type { MessageWithParts, Turn } from "./plan";
 import { allocateOmission } from "../storage/omission";
 import { isRecord, unwrapString } from "../util";
@@ -18,6 +15,10 @@ const DEFAULT_OUTPUT_DESCRIPTION =
 
 const DEFAULT_LIMIT = { words: 128, chars: 1024 };
 const TASK_OUTPUT_LIMIT = { words: 512, chars: 4096 };
+// webfetch frequently returns large HTML/markdown pages — always omit with cache
+const WEBFETCH_LIMIT = { words: 64, chars: 512 };
+// glob/grep outputs are file lists / search results — compact aggressively
+const SEARCH_LIMIT = { words: 64, chars: 512 };
 
 export async function pruneSummarizedTurns(
   context: PruneContext,
@@ -243,6 +244,52 @@ async function applyOutputOmissions(
       });
       part.state.output = outputOmissionNotice(
         "Task output omitted due to a compaction operation. If necessary, reread output via read_omitted_content tool.",
+        output.length,
+        contentID,
+      );
+    }
+    return;
+  }
+
+  // webfetch: HTML/markdown pages are large and stale — always omit above threshold.
+  // The URL is preserved in the tool input so the agent can re-fetch if needed.
+  if (part.tool === "webfetch" || part.tool === "mcp_Webfetch") {
+    if (exceeds(output, WEBFETCH_LIMIT)) {
+      const contentID = await allocateOmission(context.sessionID, {
+        content: output,
+      });
+      part.state.output = outputOmissionNotice(
+        "Web page contents omitted due to compaction operation. Re-fetch the URL from tool input if current contents are needed.",
+        output.length,
+        contentID,
+      );
+    }
+    return;
+  }
+
+  // glob: file listing results are reproducible — omit above threshold.
+  if (part.tool === "glob" || part.tool === "mcp_Glob") {
+    if (exceeds(output, SEARCH_LIMIT)) {
+      const contentID = await allocateOmission(context.sessionID, {
+        content: output,
+      });
+      part.state.output = outputOmissionNotice(
+        "Glob file listing omitted due to compaction operation. Re-run glob with the same pattern to reproduce.",
+        output.length,
+        contentID,
+      );
+    }
+    return;
+  }
+
+  // grep: search results are reproducible — omit above threshold.
+  if (part.tool === "grep" || part.tool === "mcp_Grep") {
+    if (exceeds(output, SEARCH_LIMIT)) {
+      const contentID = await allocateOmission(context.sessionID, {
+        content: output,
+      });
+      part.state.output = outputOmissionNotice(
+        "Grep search results omitted due to compaction operation. Re-run grep with the same pattern to reproduce.",
         output.length,
         contentID,
       );


### PR DESCRIPTION
## Summary

Adds pruning support for three tool types commonly used in agentic workflows that weren't handled by the existing pruner:

### `webfetch` / `mcp_Webfetch`
Web page contents fetched during a session become stale immediately after the request — the agent can always re-fetch the URL (preserved in tool input) if current content is needed. Omitting these aggressively (64 words / 512 chars threshold) recovers significant tokens since HTML/markdown pages are large.

### `glob` / `mcp_Glob`  
File listing results are fully reproducible by re-running the same pattern. Safe to omit above threshold.

### `grep` / `mcp_Grep`
Search results are reproducible. Safe to omit above threshold.

Both `glob` and `grep` use a shared `SEARCH_LIMIT` (64 words / 512 chars). All omitted content is cached via `allocateOmission` and retrievable with `read_omitted_content`.

### MCP compatibility
Tool names are matched with both plain (`webfetch`, `glob`, `grep`) and MCP-prefixed (`mcp_Webfetch`, `mcp_Glob`, `mcp_Grep`) variants, since MCP tool names get prefixed differently depending on the client.