### PR TITLE
fix: tolerate the extra trailing summary models append for the next-turn anchor

### DIFF
--- a/packages/claude-code-plugin/src/compact.ts
+++ b/packages/claude-code-plugin/src/compact.ts
@@ -463,6 +463,7 @@ ${getUserPromptText(turn)}
 <user>
 ${getUserPromptText(nextTurn)}
 </user>
+[**Do not add an <assistant> summary for the final <user> above; it marks where summarization stops and the template ends here.**]
 `.trim(),
     );
   }
@@ -491,12 +492,29 @@ function parseSummaries(responseText: string, expectedCount: number): string[] {
   }
 
   const summary = responseText.slice(start, end + "</summary>".length);
-  const matches = [
-    ...summary.matchAll(/<assistant>([\s\S]*?)<\/assistant>/g),
-  ].map(match => match[1]!.trim());
+  // Models regularly append one unrequested summary for the trailing
+  // next-turn <user> anchor. Pairing each echoed <user> with its following
+  // <assistant> and taking the first expectedCount pairs ignores that extra
+  // block while still failing loudly on a true miss.
+  const segments = [
+    ...summary.matchAll(/<(user|assistant)>([\s\S]*?)<\/\1>/g),
+  ].map(match => ({ tag: match[1]!, text: match[2]!.trim() }));
+  const matches: string[] = [];
+  for (
+    let index = 0;
+    index < segments.length && matches.length < expectedCount;
+    index++
+  ) {
+    const current = segments[index]!;
+    const next = segments[index + 1];
+    if (current.tag === "user" && next?.tag === "assistant") {
+      matches.push(next.text);
+      index++;
+    }
+  }
   if (matches.length !== expectedCount) {
     throw new Error(
-      `Expected ${expectedCount} summaries, received ${matches.length}.`,
+      `Expected ${expectedCount} summaries, received ${matches.length} user/assistant pairs.`,
     );
   }
   return matches;

--- a/packages/opencode-plugin/src/compact/compact.ts
+++ b/packages/opencode-plugin/src/compact/compact.ts
@@ -90,13 +90,30 @@ async function generateSummaries(
 
 function parseSummaries(responseText: string, expectedCount: number): string[] {
   const summary = extractSummaryXml(responseText);
-  const matches = [
-    ...summary.matchAll(/<assistant>([\s\S]*?)<\/assistant>/g),
-  ].map(match => match[1]!.trim());
+  // Models regularly append one unrequested summary for the trailing
+  // next-turn <user> anchor. Pairing each echoed <user> with its following
+  // <assistant> and taking the first expectedCount pairs ignores that extra
+  // block while still failing loudly on a true miss.
+  const segments = [
+    ...summary.matchAll(/<(user|assistant)>([\s\S]*?)<\/\1>/g),
+  ].map(match => ({ tag: match[1]!, text: match[2]!.trim() }));
+  const matches: string[] = [];
+  for (
+    let index = 0;
+    index < segments.length && matches.length < expectedCount;
+    index++
+  ) {
+    const current = segments[index]!;
+    const next = segments[index + 1];
+    if (current.tag === "user" && next?.tag === "assistant") {
+      matches.push(next.text);
+      index++;
+    }
+  }
 
   if (matches.length !== expectedCount) {
     throw new Error(
-      `Expected ${expectedCount} summaries, received ${matches.length}.`,
+      `Expected ${expectedCount} summaries, received ${matches.length} user/assistant pairs.`,
     );
   }
 

--- a/packages/opencode-plugin/src/compact/template.ts
+++ b/packages/opencode-plugin/src/compact/template.ts
@@ -67,6 +67,7 @@ ${getUserPromptText(turn)}
 <user>
 ${getUserPromptText(nextTurn)}
 </user>
+[**Do not add an <assistant> summary for the final <user> above; it marks where summarization stops and the template ends here.**]
 `.trim(),
     );
   }


### PR DESCRIPTION
## Problem

`buildXmlTemplate` ends the compaction template with a trailing `<user>` block that anchors where summarization stops. Summarizer models regularly "complete" that anchor with one extra, unrequested `<assistant>` block. `parseSummaries` validates by counting `<assistant>` blocks, so the otherwise-correct response is rejected ("Expected 7 summaries, received 8") and the compaction aborts.

Observed on the Claude Code plugin: with Haiku 4.5 as the summarizer, 3 of 3 attempts on a ~380-row transcript failed (this shape plus two other malformed-output shapes); with Sonnet 5, one occurrence of the +1 shape. Both plugins share the parsing logic, so both are affected.

## Fix

- `parseSummaries` now pairs each echoed `<user>` block with the `<assistant>` block that follows it and takes exactly the first `expectedCount` pairs. The extra trailing block is ignored; a true miss or malformed structure still throws.
- The template marks the trailing next-turn `<user>` as not-to-be-summarized, reducing the extra block at the source.

## Verification

- Claude Code side: the same transcript that reproducibly failed with "Expected 7, received 8" compacts cleanly with the patched parsing (failure observed first, then the fix, then green). Tested via a locally adapted copy of the plugin engine; the two changed functions are identical to this diff.
- OpenCode side: the same mechanical change; `tsc --noEmit`, `eslint`, and `prettier` all pass.

One environment note in passing: the `.githooks/pre-commit` `npx` invocations cannot resolve bun-installed binaries on Windows (bun's store has no npm-visible bin entries there), so the hook fails closed for Windows contributors even on a clean tree. Happy to file that separately if useful.
