### PR TITLE
fix(opencode): fork source session so summarizer sees the conversation

### DIFF
--- a/docs/OpenCode.md
+++ b/docs/OpenCode.md
@@ -21,7 +21,7 @@ OpenCode-specific runtime behavior. Shared plugin behavior lives in [`Core.md`](
 7. Rename the backup to `[Backup] ${title} ${timestamp}` and write backup metadata.
 8. Measure pre-compaction tokens using provider tokens when available, otherwise local counting.
 9. Insert an ignored no-reply progress message.
-10. Create an ephemeral compaction session.
+10. Fork the source session into an ephemeral compaction session so the summarizer sees the full conversation.
 11. Send the XML summary prompt in the ephemeral session.
 12. Parse per-turn summaries.
 13. Delete the ephemeral session in cleanup.
@@ -62,6 +62,7 @@ OpenCode-specific runtime behavior. Shared plugin behavior lives in [`Core.md`](
 ## Summarization
 
 - Summaries are generated in an ephemeral session so the prompt and assistant stream stay out of the main session.
+- The ephemeral session is a fork of the source session: the summarizer needs the full conversation in context to summarize assistant turns faithfully.
 - The XML prompt is built from the OpenCode template.
 - The XML prompt includes only the turns being summarized and, when needed, the next user turn as the boundary marker.
 - User text in the prompt excludes synthetic and ignored text and is truncated to the first line or first 300 characters, whichever is shorter.

--- a/packages/opencode-plugin/src/compact/compact.ts
+++ b/packages/opencode-plugin/src/compact/compact.ts
@@ -37,17 +37,18 @@ async function generateSummariesInEphemeralSession(
   turns: Turn[],
   nextTurn: Turn | null,
 ): Promise<string[]> {
+  // Fork the source session so the summarizer sees the full conversation it
+  // is asked to summarize. A freshly created session has no history: the
+  // model would only receive the truncated user lines embedded in the
+  // template and could not produce faithful per-turn summaries.
   const compactionSession = unwrap(
-    await v2.session.create({
+    await v2.session.fork({ sessionID: session.id }),
+  );
+
+  unwrap(
+    await v2.session.update({
+      sessionID: compactionSession.id,
       title: `[TEMP] ${session.title}`,
-      agent: session.agent,
-      model: session.model
-        ? {
-            id: session.model.id,
-            providerID: session.model.providerID,
-            variant: session.model.variant,
-          }
-        : undefined,
     }),
   );
 

--- a/packages/opencode-plugin/src/compact/compact.ts
+++ b/packages/opencode-plugin/src/compact/compact.ts
@@ -45,14 +45,14 @@ async function generateSummariesInEphemeralSession(
     await v2.session.fork({ sessionID: session.id }),
   );
 
-  unwrap(
-    await v2.session.update({
-      sessionID: compactionSession.id,
-      title: `[TEMP] ${session.title}`,
-    }),
-  );
-
   try {
+    unwrap(
+      await v2.session.update({
+        sessionID: compactionSession.id,
+        title: `[TEMP] ${session.title}`,
+      }),
+    );
+
     return await generateSummaries(v2, compactionSession.id, turns, nextTurn);
   } finally {
     unwrap(


### PR DESCRIPTION
Fixes #9

## Problem

The OpenCode summarizer runs in an ephemeral session created with `session.create`. A fresh session has no history, and the XML template embeds only truncated first-line user text, so the model never sees the assistant turns it is asked to summarize and fabricates them from user fragments. Reproducible probe in #9: an invented codename `GLYPH FORGE` (present only in an assistant turn) was summarized as `SHADOW PARSER`, with compaction reporting success.

## Solution

Create the ephemeral session with `session.fork({ sessionID })` and retitle it `[TEMP] ...`. The summarizer now has the full conversation in context, while the summarization prompt and assistant stream still stay out of the main session, which keeps the documented behavior in `docs/OpenCode.md` intact. Docs updated accordingly.

## Verification

Probe against an OpenCode server built from recent source with a live model, planting facts that exist only in assistant turns:

- invented codename recalled exactly (`GLYPH FORGE`); a file-read turn summarized with an accurate description of the real file content, including the correct line count
- summarized assistant text/reasoning parts pruned; tool parts preserved; large tool output omitted and retrievable from the omission cache; user messages preserved byte-identical
- backup and rollback paths untouched

Happy to adjust to repo conventions.


---

Process note: Human-driven and reviewed, with agentic assistance from anthropic/claude-fable-5/max.
