### PR TITLE
fix: use consistent token metric for before/after compaction stats

### DIFF
--- a/packages/opencode-plugin/src/magic-compact.metric-consistency.test.ts
+++ b/packages/opencode-plugin/src/magic-compact.metric-consistency.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+// Regression guard for the bug where the compaction stats notice compared
+// beforeTokens (getProviderTokens: real provider usage, same field OpenCode's
+// own sidebar "used Xk" indicator reads) against afterTokens
+// (countSessionTokens: a local text re-estimate). The two numbers came from
+// unrelated data sources, so "before -> after (% reduced)" had no reliable
+// relationship to what the user actually saw in OpenCode's context indicator
+// afterward.
+//
+// Fix: both beforeTokens and afterTokens must be computed with
+// countSessionTokens, so the printed reduction is at least internally
+// consistent. This test fails loudly (source-level guard) if
+// getProviderTokens is reintroduced into magic-compact.ts's before/after
+// comparison, without needing a full mocked v2 client / integration harness.
+describe("magic-compact.ts before/after token metric consistency", () => {
+  it("does not import getProviderTokens (a comment may still explain why, for documentation)", () => {
+    const path = fileURLToPath(new URL("./magic-compact.ts", import.meta.url));
+    const source = readFileSync(path, "utf8");
+    const importLine = source
+      .split("\n")
+      .find(line => line.includes('from "./stats/tokenize"'));
+
+    expect(importLine).toBeDefined();
+    expect(importLine).not.toContain("getProviderTokens");
+    expect(importLine).toContain("countSessionTokens");
+  });
+
+  it("computes beforeTokens and afterTokens with the exact same call shape", () => {
+    const path = fileURLToPath(new URL("./magic-compact.ts", import.meta.url));
+    const source = readFileSync(path, "utf8");
+
+    const beforeCall =
+      /const beforeTokens = await countSessionTokens\(v2, sessionID\);/;
+    const afterCall =
+      /const afterTokens = await countSessionTokens\(v2, sessionID\);/;
+
+    expect(source).toMatch(beforeCall);
+    expect(source).toMatch(afterCall);
+  });
+});

--- a/packages/opencode-plugin/src/magic-compact.ts
+++ b/packages/opencode-plugin/src/magic-compact.ts
@@ -15,7 +15,7 @@ import {
 } from "./compact/session";
 import { createCompactionPlan } from "./compact/plan";
 import { pruneSummarizedTurns } from "./compact/prune";
-import { countSessionTokens, getProviderTokens } from "./stats/tokenize";
+import { countSessionTokens } from "./stats/tokenize";
 
 export const COMPACT_SUCCESS = "Magic compaction successful.";
 export const COMPACT_NOOP = "No assistant turns are old enough to compact.";
@@ -54,9 +54,19 @@ export async function executeMagicCompact(
       currentCompactionCount,
     );
 
-    const beforeTokens =
-      (await getProviderTokens(v2, sessionID))
-      ?? (await countSessionTokens(v2, sessionID));
+    // beforeTokens and afterTokens MUST use the same measurement method.
+    // getProviderTokens reads message.info.tokens, a field the provider sets
+    // once, at generation time, on a specific past assistant message — it is
+    // never updated by pruning and is also what OpenCode's own "used Xk"
+    // sidebar indicator reads. Mixing it with a local re-estimate for
+    // afterTokens produced a stats notice ("X -> Y tokens") whose two sides
+    // came from unrelated data sources, so the printed reduction had no
+    // reliable relationship to what the sidebar showed next. Using
+    // countSessionTokens for both keeps the comparison internally
+    // consistent, at the cost of it not matching the sidebar's own number
+    // (which cannot reflect this compaction until the next real completion
+    // call regardless of how beforeTokens is computed).
+    const beforeTokens = await countSessionTokens(v2, sessionID);
 
     const progressMessageID = await injectProgressNotice(v2, sessionID);
     let compacted;

--- a/packages/opencode-plugin/src/stats/constants.ts
+++ b/packages/opencode-plugin/src/stats/constants.ts
@@ -45,6 +45,7 @@ Magic Compaction #${compactionCount}
 Compaction Stats   | ${formatTokenCount(beforeTokens)} → ${formatTokenCount(afterTokens)} tokens (${percent}% reduced) | ~${formatTokenCount(savedTokens)} tokens pruned
 Conversation Stats | Total tokens pruned: ~${formatTokenCount(stats.totalTokensPruned)} | Total cache reads saved: ~${formatTokenCount(stats.cachedTokensSaved)} tokens
 Cost Savings       | ${moneySaved}
+Note: this is an estimate of the reduced conversation; OpenCode's context/"used" indicator updates on your next message, not immediately.
 `.trim();
 }
 


### PR DESCRIPTION
## Problem

After running `/magic-compact`, the printed stats notice ("X -> Y tokens (Z% reduced)") had no reliable relationship to what OpenCode's own sidebar "used Xk" context indicator showed afterward. A user reported the toast said turns were pruned, yet the sidebar barely moved (e.g. 130k -> 114k, not tracking the reported reduction at all).

## Root cause

`executeMagicCompact` mixed two unrelated token-measurement methods:

- `beforeTokens` used `getProviderTokens`, which reads `message.info.tokens` — a field the **provider** sets once, at generation time, on a specific past assistant message. This is the exact same field OpenCode's own sidebar reads (`packages/tui/src/feature-plugins/sidebar/context.tsx`), so `beforeTokens` matched the UI.
- `afterTokens` used `countSessionTokens`, a **local** re-estimate that walks the (now-pruned) message parts with `gpt-tokenizer`.

Pruning (`prune.ts`) mutates/deletes message *parts*, but never touches `message.info.tokens` on already-generated messages (that field is immutable provider telemetry). So after compaction, the sidebar's real "used Xk" is simply whichever historical `tokens` field survives on the new last assistant message — unrelated to what `countSessionTokens` computed as `afterTokens`. Comparing the two produced a stats message whose numbers came from two disconnected data sources.

## Fix

Use `countSessionTokens` for both `beforeTokens` and `afterTokens`, so the printed reduction is at least internally consistent (same tokenizer, same method, same data source). This cannot make the number match OpenCode's live sidebar indicator — that field only updates on the next real completion call, which is a constraint of OpenCode core, not this plugin — so a clarifying note was added to the stats message.

## Testing

- `magic-compact.metric-consistency.test.ts` (new): source-level regression guard asserting `magic-compact.ts` no longer imports `getProviderTokens` and that both `beforeTokens`/`afterTokens` are computed via the identical `countSessionTokens(v2, sessionID)` call.
- `bun install && bun run typecheck && bun run lint && bun test`: all pass.

## Non-goals

Does not attempt to make the stats notice match OpenCode's sidebar indicator in real time — that's an OpenCode-core constraint (the indicator only refreshes on the next completion call), out of scope for this plugin.