### PR TITLE
fix(OC): Use configured compaction agent for summaries

### DIFF
--- a/docs/Development.md
+++ b/docs/Development.md
@@ -39,6 +39,7 @@ bun install
   - `src/stats/events.ts` - stats event accounting.
   - `src/stats/pricing.ts` - pricing calculations.
   - `src/stats/tokenize.ts` - token estimation helpers.
+  - `test/compact.test.ts` - compaction prompt-agent and ephemeral-session lifecycle tests.
   - `test/trim.test.ts` - trim planning and metadata idempotency tests.
 - `packages/claude-code-plugin` - Claude Code plugin implementation for the port.
   - `src/command.ts` - Claude Code slash command entrypoint.

--- a/docs/OpenCode.md
+++ b/docs/OpenCode.md
@@ -23,7 +23,7 @@ OpenCode-specific runtime behavior. Shared plugin behavior lives in [`Core.md`](
 8. Measure pre-compaction tokens using provider tokens when available, otherwise local counting.
 9. Insert an ignored no-reply progress message.
 10. Fork the source session into an ephemeral compaction session so the summarizer sees the full conversation.
-11. Send the XML summary prompt in the ephemeral session.
+11. Send the XML summary prompt in the ephemeral session using OpenCode's hidden `compaction` agent.
 12. Parse per-turn summaries.
 13. Delete the ephemeral session in cleanup.
 14. Delete the progress message in cleanup.
@@ -85,7 +85,10 @@ Known issues: We do not check for noops.
 
 - Summaries are generated in an ephemeral session so the prompt and assistant stream stay out of the main session.
 - The ephemeral session is a fork of the source session: the summarizer needs the full conversation in context to summarize assistant turns faithfully.
+- Summary generation is an ordinary `session.prompt()` request that explicitly selects OpenCode's hidden `compaction` agent. It is not OpenCode's native `session.compact()` operation.
+- OpenCode applies the `compaction` agent's configured model, prompt, options, and permissions. When that agent has no configured model, model selection falls through OpenCode's normal prompt resolution.
 - The XML prompt is built from the OpenCode template.
+- The Magic Compact XML request and response contract remains authoritative even when the `compaction` agent has a configured prompt.
 - The XML prompt includes only the turns being summarized and, when needed, the next user turn as the boundary marker.
 - User text in the prompt excludes synthetic and ignored text and is truncated to the first line or first 300 characters, whichever is shorter.
 - The generated XML must contain one `<assistant>` summary for each summarized turn.
@@ -154,6 +157,7 @@ Known issues: We do not check for noops.
 ## Error Handling
 
 - Any LLM, XML, SDK, cache, stats, token counting, or pruning failure aborts the attempt.
+- If the `compaction` agent is disabled or missing, the prompt failure aborts the attempt without falling back to another agent.
 - Cleanup deletes the ephemeral session and progress message when they exist.
 - If a backup exists, it is promoted back.
 - A failure toast is shown.

--- a/packages/opencode-plugin/src/compact/compact.ts
+++ b/packages/opencode-plugin/src/compact/compact.ts
@@ -72,6 +72,7 @@ async function generateSummaries(
   const response = unwrap(
     await v2.session.prompt({
       sessionID,
+      agent: "compaction",
       parts: [
         {
           type: "text",

--- a/packages/opencode-plugin/test/compact.test.ts
+++ b/packages/opencode-plugin/test/compact.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from "bun:test";
+import type { Message, Part, Session, TextPart } from "@opencode-ai/sdk/v2";
+import type { V2Client } from "../src/api";
+import { compactSession } from "../src/compact/compact";
+import type { MessageWithParts } from "../src/compact/plan";
+
+describe("magic compact", () => {
+  test("prompts the native compaction agent with the Magic Compact XML and cleans up", async () => {
+    const promptRequests: unknown[] = [];
+    const deletedSessionIDs: string[] = [];
+    const messages = compactableMessages();
+    const v2 = {
+      session: {
+        messages: async () => ({ data: messages }),
+        fork: async () => ({ data: session("ephemeral") }),
+        update: async () => ({ data: session("ephemeral") }),
+        prompt: async (request: unknown) => {
+          promptRequests.push(request);
+          return {
+            data: {
+              parts: [
+                textPart(
+                  "response",
+                  "ephemeral",
+                  "response",
+                  "<summary><user>Summarize this turn\n...</user><assistant>Completed the requested work.</assistant></summary>",
+                ),
+              ],
+            },
+          };
+        },
+        delete: async ({ sessionID }: { sessionID: string }) => {
+          deletedSessionIDs.push(sessionID);
+          return { data: true };
+        },
+      },
+      part: {
+        update: async ({ part }: { part: TextPart }) => ({ data: part }),
+      },
+    } as unknown as V2Client;
+
+    await compactSession(v2, session("source"), "source", 0);
+
+    expect(promptRequests).toHaveLength(1);
+    expect(promptRequests[0]).toEqual({
+      sessionID: "ephemeral",
+      agent: "compaction",
+      parts: [
+        {
+          type: "text",
+          text: expect.stringMatching(
+            /<system>[\s\S]*Summarize this turn[\s\S]*<\/system>/,
+          ),
+        },
+      ],
+    });
+    expect(deletedSessionIDs).toEqual(["ephemeral"]);
+  });
+
+  test("propagates a missing compaction agent error after cleanup without retrying", async () => {
+    const promptRequests: unknown[] = [];
+    const deletedSessionIDs: string[] = [];
+    const v2 = {
+      session: {
+        messages: async () => ({ data: compactableMessages() }),
+        fork: async () => ({ data: session("ephemeral") }),
+        update: async () => ({ data: session("ephemeral") }),
+        prompt: async (request: unknown) => {
+          promptRequests.push(request);
+          return { error: 'Agent not found: "compaction".' };
+        },
+        delete: async ({ sessionID }: { sessionID: string }) => {
+          deletedSessionIDs.push(sessionID);
+          return { data: true };
+        },
+      },
+    } as unknown as V2Client;
+
+    await expect(
+      compactSession(v2, session("source"), "source", 0),
+    ).rejects.toThrow('Agent not found: "compaction".');
+
+    expect(promptRequests).toHaveLength(1);
+    expect(deletedSessionIDs).toEqual(["ephemeral"]);
+  });
+});
+
+function compactableMessages(): MessageWithParts[] {
+  return [
+    message("user", "user", [
+      textPart("user-text", "source", "user", "Summarize this turn"),
+    ]),
+    message("assistant", "assistant", []),
+  ];
+}
+
+function message(
+  id: string,
+  role: "user" | "assistant",
+  parts: Part[],
+): MessageWithParts {
+  return {
+    info: { id, role } as Message,
+    parts,
+  };
+}
+
+function session(id: string): Session {
+  return { id, title: "Test session" } as Session;
+}
+
+function textPart(
+  id: string,
+  sessionID: string,
+  messageID: string,
+  text: string,
+): TextPart {
+  return {
+    id,
+    sessionID,
+    messageID,
+    type: "text",
+    text,
+  };
+}


### PR DESCRIPTION
## Problem

Magic Compact sends its summary prompt without an `agent` or `model`. OpenCode therefore falls back to its default agent resolution, which can select an unrelated agent and that agent's configured model.

In my case, the Build/Kimi K3 selection never reached Magic Compact. All three failed compaction requests instead used `architect-planner` with `openai/gpt-5.6-sol-fast`. The slash-command hook only receives the command, arguments, and session ID, so the UI selection was neither forwarded nor persisted for this prompt.

## Change

- Explicitly run the existing summary prompt with `agent: "compaction"`.
- Keep Magic Compact's per-turn XML prompt and ephemeral-session lifecycle. This does not call OpenCode's native `session.compact()` operation.
- Let OpenCode apply the configured compaction agent model, prompt, options, and permissions. Missing or disabled compaction agents fail without falling back to another agent.
- Add request, cleanup, and error-path coverage and document the behavior.

## Verification

- `bun test`
- `bun run typecheck`
- `bun run lint`
- Prettier check on changed files