### PR TITLE
Correctly quote env var usage in the command in hooks.json

### DIFF
--- a/packages/claude-code-plugin/hooks/hooks.json
+++ b/packages/claude-code-plugin/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun ${CLAUDE_PLUGIN_ROOT}/src/hook.ts",
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/src/hook.ts\"",
             "timeout": 150,
             "statusMessage": "Running Magic Compact"
           }


### PR DESCRIPTION
When trying to use the plugin, I was stopped by the issue with unquoted variable expansion in path in the hook command. I have a whitespace in my username, so the path was splitted and Claude tried to run a non-existent script. After adding quotes, the command works as expected.